### PR TITLE
Refactor/#31 유저 레포지토리 관련 서비스 메소드 통합

### DIFF
--- a/src/main/java/com/group6/accommodation/domain/auth/repository/UserRepository.java
+++ b/src/main/java/com/group6/accommodation/domain/auth/repository/UserRepository.java
@@ -19,4 +19,10 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
                 () -> new AuthException(AuthErrorCode.NOT_FOUND_USER_BY_USER_ID)
         );
     }
+
+    default void checkExistsUserByIdOrElseThrow(@NonNull Long id) {
+        if (!existsById(id)) {
+            throw new AuthException(AuthErrorCode.NOT_FOUND_USER_BY_USER_ID);
+        }
+    }
 }

--- a/src/main/java/com/group6/accommodation/domain/auth/repository/UserRepository.java
+++ b/src/main/java/com/group6/accommodation/domain/auth/repository/UserRepository.java
@@ -16,7 +16,7 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
     @NonNull
     default UserEntity getById(@NonNull Long id) {
         return findById(id).orElseThrow(
-                () -> new AuthException(AuthErrorCode.NOT_FOUNT_USER_BY_USER_ID)
+                () -> new AuthException(AuthErrorCode.NOT_FOUND_USER_BY_USER_ID)
         );
     }
 }

--- a/src/main/java/com/group6/accommodation/domain/auth/service/UserService.java
+++ b/src/main/java/com/group6/accommodation/domain/auth/service/UserService.java
@@ -32,8 +32,7 @@ public class UserService {
     private Long refreshTokenExpireTime;
 
     public UserResponseDto getUserInfo(Long userId) {
-        UserEntity result = userRepository.findById(userId)
-                .orElseThrow(() -> new AuthException(AuthErrorCode.NOT_FOUNT_USER_BY_USER_ID));
+        UserEntity result = userRepository.getById(userId);
 
         return UserResponseDto.toResponse(result);
     }
@@ -54,9 +53,7 @@ public class UserService {
     }
 
     public HttpHeaders logout(Long userId) {
-        if (!userRepository.existsById(userId)) {
-            throw new AuthException(AuthErrorCode.NOT_FOUNT_USER_BY_USER_ID);
-        }
+        userRepository.checkExistsUserByIdOrElseThrow(userId);
 
         if (refreshTokenRepository.existsById(userId)) {
             refreshTokenRepository.deleteById(userId);

--- a/src/main/java/com/group6/accommodation/domain/likes/service/UserLikeService.java
+++ b/src/main/java/com/group6/accommodation/domain/likes/service/UserLikeService.java
@@ -35,14 +35,14 @@ public class UserLikeService {
     @Transactional
     public UserLikeResponseDto addLike(Long accommodationId, Long userId) {
         AccommodationEntity accommodationEntity = getAccommodationById(accommodationId);
-        UserEntity authEntity = getUserById(userId);
+        UserEntity userEntity = userRepository.getById(userId);
         validateAlreadyLikedAccommodation(accommodationId, userId);
 
         UserLikeId userLikeId = new UserLikeId(userId, accommodationId);
         UserLikeEntity addUserLike = UserLikeEntity.builder()
             .id(userLikeId)
             .accommodation(accommodationEntity)
-            .user(authEntity)
+            .user(userEntity)
             .build();
 
         userLikeRepository.save(addUserLike);
@@ -54,7 +54,7 @@ public class UserLikeService {
     @Transactional
     public String cancelLike(Long accommodationId, long userId) {
         getAccommodationById(accommodationId);
-        getUserById(userId);
+        userRepository.checkExistsUserByIdOrElseThrow(userId);
 
         Optional<UserLikeEntity> isExistUserLike = userLikeRepository.findByAccommodationIdAndUserId(accommodationId, userId);
 
@@ -67,7 +67,7 @@ public class UserLikeService {
     }
 
     public PagedDto<AccommodationResponseDto> getLikedAccommodation(Long userId, int page, int size) {
-        getUserById(userId);
+        userRepository.checkExistsUserByIdOrElseThrow(userId);
         PageRequest pageRequest = PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "id"));
 
         List<UserLikeEntity> userLikes = userLikeRepository.findByUserId(userId);
@@ -90,11 +90,6 @@ public class UserLikeService {
     private AccommodationEntity getAccommodationById(Long accommodationId) {
         return accommodationRepository.findById(accommodationId)
             .orElseThrow(() -> new UserLikeException(UserLikeErrorCode.ACCOMMODATION_NOT_EXIST));
-    }
-
-    private UserEntity getUserById(Long userId) {
-        return userRepository.findById(userId)
-            .orElseThrow(() -> new UserLikeException(UserLikeErrorCode.UNAUTHORIZED));
     }
 
     private void validateAlreadyLikedAccommodation(Long accommodationId, Long userId) {

--- a/src/main/java/com/group6/accommodation/global/exception/error/AuthErrorCode.java
+++ b/src/main/java/com/group6/accommodation/global/exception/error/AuthErrorCode.java
@@ -12,7 +12,7 @@ public enum AuthErrorCode implements ErrorCode {
     ALREADY_EXIST_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "이미 존재하는 휴대폰 번호입니다."),
     NOT_FOUND_USER_BY_EMAIL(HttpStatus.NOT_FOUND, "해당 이메일을 가진 유저가 없습니다."),
     NOT_MATCH_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 틀렸습니다."),
-    NOT_FOUNT_USER_BY_USER_ID(HttpStatus.NOT_FOUND, "해당 ID를 가진 유저가 없습니다."),
+    NOT_FOUND_USER_BY_USER_ID(HttpStatus.NOT_FOUND, "해당 ID를 가진 유저가 없습니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
     EMPTY_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 비어있습니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),

--- a/src/test/java/com/group6/accommodation/domain/auth/service/UserServiceTest.java
+++ b/src/test/java/com/group6/accommodation/domain/auth/service/UserServiceTest.java
@@ -90,7 +90,7 @@ public class UserServiceTest {
         AuthException exception = assertThrows(AuthException.class,
                 () -> userService.getUserInfo(2L));
 
-        assertEquals(AuthErrorCode.NOT_FOUNT_USER_BY_USER_ID.getInfo(), exception.getInfo());
+        assertEquals(AuthErrorCode.NOT_FOUND_USER_BY_USER_ID.getInfo(), exception.getInfo());
     }
 
     @Test
@@ -149,7 +149,7 @@ public class UserServiceTest {
         AuthException exception = assertThrows(AuthException.class,
                 () -> userService.logout(user.getId()));
 
-        assertEquals(AuthErrorCode.NOT_FOUNT_USER_BY_USER_ID.getInfo(), exception.getInfo());
+        assertEquals(AuthErrorCode.NOT_FOUND_USER_BY_USER_ID.getInfo(), exception.getInfo());
     }
 
     @Test


### PR DESCRIPTION
## 작업 대상
UserService에 존재하는 JPA Repository 메소드를 UserRepository Interface의 default 메소드로 변경

## 📄 작업 내용
- [x] UserService에 존재하는 JPA Repository 메소드를 UserRepository Interface의 default 메소드로 변경했습니다.
- [x] UserLikeService의 getUserById 메소드를 userRepository default 메소드로 변경하여 적용해 추상화 단계를 낮췄습니다.
- [x] NOT_FOUNT_USER_BY_USER_ID 오타를 NOT_FOUND_USER_BY_USER_ID로 수정했습니다.

## 📎 관련 이슈
closed #31