### PR TITLE
Refactor/#36 refreshTokens 기능 헤더 관련 로직 서비스 분리

### DIFF
--- a/src/main/java/com/group6/accommodation/domain/auth/controller/UserController.java
+++ b/src/main/java/com/group6/accommodation/domain/auth/controller/UserController.java
@@ -6,6 +6,7 @@ import com.group6.accommodation.domain.auth.service.UserService;
 import com.group6.accommodation.global.security.filter.JwtFilter;
 import com.group6.accommodation.global.security.service.CustomUserDetails;
 import com.group6.accommodation.global.security.token.model.dto.LoginTokenResponseDto;
+import com.group6.accommodation.global.util.CookieUtil;
 import com.group6.accommodation.global.util.ResponseApi;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -55,7 +56,7 @@ public class UserController {
         LoginTokenResponseDto result = userService.refreshTokens(accessToken, refreshToken);
         ResponseApi<LoginTokenResponseDto> refreshTokens = ResponseApi.success(HttpStatus.OK, result);
 
-        HttpHeaders headers = userService.createRefreshTokenCookie(refreshTokens.getData().getRefreshToken());
+        HttpHeaders headers = CookieUtil.createRefreshTokenCookie(refreshTokens.getData().getRefreshToken());
         return ResponseEntity.status(HttpStatus.OK).headers(headers).body(refreshTokens);
     }
 
@@ -72,11 +73,12 @@ public class UserController {
 
     @PostMapping("/api/user/logout")
     @Operation(summary = "로그아웃")
-
     public ResponseEntity<?> logout(
             @AuthenticationPrincipal CustomUserDetails user
     ) {
-        HttpHeaders headers = userService.logout(user.getUserId());
+        userService.logout(user.getUserId());
+
+        HttpHeaders headers = CookieUtil.deleteRefreshTokenCookie();
         return ResponseEntity.status(HttpStatus.NO_CONTENT).headers(headers).build();
     }
 }

--- a/src/main/java/com/group6/accommodation/domain/auth/service/UserService.java
+++ b/src/main/java/com/group6/accommodation/domain/auth/service/UserService.java
@@ -12,9 +12,6 @@ import lombok.extern.slf4j.Slf4j;
 import com.group6.accommodation.global.security.filter.JwtFilter;
 import com.group6.accommodation.global.security.token.model.dto.LoginTokenResponseDto;
 import com.group6.accommodation.global.security.token.provider.TokenProvider;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseCookie;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
@@ -28,8 +25,7 @@ public class UserService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final PasswordEncoder passwordEncoder;
     private final TokenProvider tokenProvider;
-    @Value("${jwt.refresh-expiration-time}")
-    private Long refreshTokenExpireTime;
+
 
     public UserResponseDto getUserInfo(Long userId) {
         UserEntity result = userRepository.findById(userId)
@@ -53,7 +49,7 @@ public class UserService {
         return UserResponseDto.toResponse(result);
     }
 
-    public HttpHeaders logout(Long userId) {
+    public void logout(Long userId) {
         if (!userRepository.existsById(userId)) {
             throw new AuthException(AuthErrorCode.NOT_FOUNT_USER_BY_USER_ID);
         }
@@ -63,13 +59,6 @@ public class UserService {
         } else {
             throw new AuthException(AuthErrorCode.ALREADY_LOGOUT);
         }
-
-        ResponseCookie refreshTokenCookie = deleteRefreshTokenCookie();
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
-
-        return headers;
     }
 
     private String encodePassword(String password) {
@@ -99,26 +88,4 @@ public class UserService {
         }
     }
 
-    public HttpHeaders createRefreshTokenCookie(String refreshToken) {
-        ResponseCookie refreshTokenCookie = ResponseCookie
-                .from("refreshToken", refreshToken)
-                .maxAge(refreshTokenExpireTime)
-                .path("/")
-                .httpOnly(true)
-                .secure(true)
-                .build();
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
-
-        return headers;
-    }
-
-    private ResponseCookie deleteRefreshTokenCookie() {
-        return ResponseCookie
-                .from("refreshToken", "")
-                .maxAge(0)
-                .path("/api")
-                .build();
-    }
 }

--- a/src/main/java/com/group6/accommodation/global/util/CookieUtil.java
+++ b/src/main/java/com/group6/accommodation/global/util/CookieUtil.java
@@ -1,0 +1,44 @@
+package com.group6.accommodation.global.util;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+public final class CookieUtil {
+
+    @Value("${jwt.refresh-expiration-time}")
+    private static Long refreshTokenExpireTime;
+
+    private CookieUtil() {
+    }
+
+    public static HttpHeaders createRefreshTokenCookie(String refreshToken) {
+        ResponseCookie refreshTokenCookie = ResponseCookie
+                .from("refreshToken", refreshToken)
+                .maxAge(refreshTokenExpireTime)
+                .path("/")
+                .httpOnly(true)
+                .secure(true)
+                .build();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+
+        return headers;
+    }
+
+    public static HttpHeaders deleteRefreshTokenCookie() {
+        ResponseCookie refreshTokenCookie = ResponseCookie
+                .from("refreshToken", "")
+                .maxAge(0)
+                .path("/")
+                .build();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+
+        return headers;
+    }
+}


### PR DESCRIPTION
<!-- PR 예시 : Refactor/#2 UserEntity 수정 --!>
<!-- 라벨과 리뷰어를 등록해주세요. -->

## 작업 대상
<!-- 작업한 대상을 자세히 설명해주세요. -->
refreshTokens 기능 헤더 관련 로직 서비스 분리

## 📄 작업 내용
<!-- 작업한 내용을 간단히 요약해주세요. -->
RefreshToken을 Cookie에 추가하는 로직이 Service 레이어에 존재하던 문제점을 수정하였습니다.
Header와 관련된 로직은 Controller나 Util에 있는 것이 각 레이어의 책임 분리 면에서 확실했기에 Utility Class를 만들어 메소드를 분리하였습니다.

## 📎 관련 이슈
<!-- merge 시 close할 issue 번호를 입력해주세요. -->

closed #36
